### PR TITLE
Use stderr instead of stdout, so programs can be piped

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ end
 
 `total`: total ticks (default: 100)
 
+`use_stdout`: if true, write progress bar to standard output, otherwise standard error (default: false)
+
 ## TODO
 
 - [ ] Bar format

--- a/src/progress.cr
+++ b/src/progress.cr
@@ -1,11 +1,12 @@
 require "./progress/*"
 
 class ProgressBar
-  property complete, incomplete, step, width, total
+  property complete, incomplete, step, width, total, output_stream : IO::FileDescriptor
   getter current
 
-  def initialize(@total = 100, @step = 1, @width = 100, @complete = "\u2593", @incomplete = "\u2591")
+  def initialize(@total = 100, @step = 1, @width = 100, @complete = "\u2593", @incomplete = "\u2591", use_stdout = false)
     @current = 0.0
+    @output_stream = use_stdout ? STDOUT : STDERR
   end
 
   def inc
@@ -48,10 +49,10 @@ class ProgressBar
   end
 
   private def print(percent)
-    STDERR.flush
-    STDERR.print "[#{@complete * position}#{@incomplete * (@width - position)}]  #{percent} % \r"
-    STDERR.flush
-    STDERR.print "\n" if done?
+    @output_stream.flush
+    @output_stream.print "[#{@complete * position}#{@incomplete * (@width - position)}]  #{percent} % \r"
+    @output_stream.flush
+    @output_stream.print "\n" if done?
   end
 
   private def position

--- a/src/progress.cr
+++ b/src/progress.cr
@@ -31,12 +31,12 @@ class ProgressBar
     end
 
     @current = n if @total >= n && n >= 0
-    print
+    print(percent)
   end
 
   def done
     @current = @total
-    print
+    print(percent)
   end
 
   def done?
@@ -48,9 +48,10 @@ class ProgressBar
   end
 
   private def print(percent)
-    STDOUT.flush
-    STDOUT.print "[#{@complete * position}#{@incomplete * (@width - position)}]  #{percent} % \r"
-    puts if done?
+    STDERR.flush
+    STDERR.print "[#{@complete * position}#{@incomplete * (@width - position)}]  #{percent} % \r"
+    STDERR.flush
+    STDERR.print "\n" if done?
   end
 
   private def position


### PR DESCRIPTION
* Use stdout instead of stderr so you can pipe data to other programs without having progress bar rendered into the stream
* Fix compile errors in `progress.cr`
* Flush after rendering the progress bar (otherwise `examples/exact.cr` skips the second last value for me)